### PR TITLE
Introduce basic Fluent localization

### DIFF
--- a/ui/desktop/package-lock.json
+++ b/ui/desktop/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@ai-sdk/openai": "^0.0.72",
         "@ai-sdk/ui-utils": "^1.0.2",
+        "@fluent/bundle": "^0.19.1",
+        "@fluent/react": "^0.15.2",
         "@hey-api/client-fetch": "^0.8.1",
         "@radix-ui/react-accordion": "^1.2.2",
         "@radix-ui/react-avatar": "^1.1.1",
@@ -1810,6 +1812,47 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
+    },
+    "node_modules/@fluent/bundle": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@fluent/bundle/-/bundle-0.19.1.tgz",
+      "integrity": "sha512-SWJLZrPamDPsJlFFOW1nkgN0j0rbPbmSdmK0XAoXlyqKieLtMVl4vzng3aR5pwKoUx0scug8+YY2oct3fdfy9A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@fluent/react": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@fluent/react/-/react-0.15.2.tgz",
+      "integrity": "sha512-M2klqXTUJTD8o2VDm6vEXApE/pSc16YtB7DSZ/Q8cPYF63FgDkvquVLHjzzG1PvrK9JlKJKPzl3wJ7hTAqSK4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fluent/sequence": "^0.8.0",
+        "cached-iterable": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "@fluent/bundle": ">=0.16.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@fluent/sequence": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@fluent/sequence/-/sequence-0.8.0.tgz",
+      "integrity": "sha512-eV5QlEEVV/wR3AFQLXO67x4yPRPQXyqke0c8yucyMSeW36B3ecZyVFlY1UprzrfFV8iPJB4TAehDy/dLGbvQ1Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "@fluent/bundle": ">= 0.13.0"
+      }
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -5724,6 +5767,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cached-iterable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/cached-iterable/-/cached-iterable-0.3.0.tgz",
+      "integrity": "sha512-MDqM6TpBVebZD4UDtmlFp8EjVtRcsB6xt9aRdWymjk0fWVUUGgmt/V7o0H0gkI2Tkvv8B0ucjidZm4mLosdlWw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.9.0"
       }
     },
     "node_modules/call-bind": {

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -85,6 +85,8 @@
   "dependencies": {
     "@ai-sdk/openai": "^0.0.72",
     "@ai-sdk/ui-utils": "^1.0.2",
+    "@fluent/bundle": "^0.19.1",
+    "@fluent/react": "^0.15.2",
     "@hey-api/client-fetch": "^0.8.1",
     "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-avatar": "^1.1.1",

--- a/ui/desktop/src/components/AgentHeader.en.ftl
+++ b/ui/desktop/src/components/AgentHeader.en.ftl
@@ -1,0 +1,2 @@
+agent-label = Agent
+change-profile = change profile

--- a/ui/desktop/src/components/AgentHeader.tsx
+++ b/ui/desktop/src/components/AgentHeader.tsx
@@ -1,3 +1,5 @@
+import { useLocalization } from '@fluent/react';
+
 interface AgentHeaderProps {
   title: string;
   profileInfo?: string;
@@ -5,12 +7,13 @@ interface AgentHeaderProps {
 }
 
 export function AgentHeader({ title, profileInfo, onChangeProfile }: AgentHeaderProps) {
+  const { l10n } = useLocalization();
   return (
     <div className="flex items-center justify-between px-4 py-2 border-b border-borderSubtle">
       <div className="flex items-center">
         <span className="w-2 h-2 rounded-full bg-blockTeal mr-2" />
         <span className="text-sm">
-          <span className="text-textSubtle">Agent</span>{' '}
+          <span className="text-textSubtle">{l10n.getString('agent-label')}</span>{' '}
           <span className="text-textStandard">{title}</span>
         </span>
       </div>
@@ -19,7 +22,7 @@ export function AgentHeader({ title, profileInfo, onChangeProfile }: AgentHeader
           <span className="text-textSubtle">{profileInfo}</span>
           {onChangeProfile && (
             <button onClick={onChangeProfile} className="ml-2 text-blockTeal hover:underline">
-              change profile
+              {l10n.getString('change-profile')}
             </button>
           )}
         </div>

--- a/ui/desktop/src/components/ApiKeyWarning.en.ftl
+++ b/ui/desktop/src/components/ApiKeyWarning.en.ftl
@@ -1,0 +1,7 @@
+credentials-required = Credentials Required
+credentials-description = To use Goose, you need to set environment variables for one of the following providers:
+openai-configuration = OpenAI Configuration
+anthropic-configuration = Anthropic (Claude) Configuration
+databricks-configuration = Databricks Configuration
+openrouter-configuration = OpenRouter Configuration
+credentials-after = After setting these variables, restart Goose for the changes to take effect.

--- a/ui/desktop/src/components/ApiKeyWarning.tsx
+++ b/ui/desktop/src/components/ApiKeyWarning.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocalization } from '@fluent/react';
 import { Card } from './ui/card';
 import { Bird } from './ui/icons';
 import { ChevronDown } from './icons';
@@ -52,6 +53,7 @@ export GOOSE_PROVIDER__MODEL=anthropic/claude-3.5-sonnet
 export GOOSE_PROVIDER__API_KEY=your_api_key_here`;
 
 export function ApiKeyWarning({ className }: ApiKeyWarningProps) {
+  const { l10n } = useLocalization();
   return (
     <Card
       className={`flex flex-col items-center p-8 space-y-6 bg-card-gradient w-full h-full ${className}`}
@@ -60,30 +62,30 @@ export function ApiKeyWarning({ className }: ApiKeyWarningProps) {
         <Bird />
       </div>
       <div className="text-center space-y-4 max-w-2xl w-full">
-        <h2 className="text-2xl font-semibold text-gray-800">Credentials Required</h2>
+        <h2 className="text-2xl font-semibold text-gray-800">{l10n.getString('credentials-required')}</h2>
         <p className="text-gray-600 mb-4">
-          To use Goose, you need to set environment variables for one of the following providers:
+          {l10n.getString('credentials-description')}
         </p>
 
         <div className="text-left">
-          <Collapsible title="OpenAI Configuration" defaultOpen={true}>
+          <Collapsible title={l10n.getString('openai-configuration')} defaultOpen={true}>
             <pre className="bg-gray-50 p-4 rounded-md text-sm">{OPENAI_CONFIG}</pre>
           </Collapsible>
 
-          <Collapsible title="Anthropic (Claude) Configuration">
+          <Collapsible title={l10n.getString('anthropic-configuration')}>
             <pre className="bg-gray-50 p-4 rounded-md text-sm">{ANTHROPIC_CONFIG}</pre>
           </Collapsible>
 
-          <Collapsible title="Databricks Configuration">
+          <Collapsible title={l10n.getString('databricks-configuration')}>
             <pre className="bg-gray-50 p-4 rounded-md text-sm">{DATABRICKS_CONFIG}</pre>
           </Collapsible>
 
-          <Collapsible title="OpenRouter Configuration">
+          <Collapsible title={l10n.getString('openrouter-configuration')}>
             <pre className="bg-gray-50 p-4 rounded-md text-sm">{OPENROUTER_CONFIG}</pre>
           </Collapsible>
         </div>
         <p className="text-gray-600 mt-4">
-          After setting these variables, restart Goose for the changes to take effect.
+          {l10n.getString('credentials-after')}
         </p>
       </div>
     </Card>

--- a/ui/desktop/src/ftl.d.ts
+++ b/ui/desktop/src/ftl.d.ts
@@ -1,0 +1,4 @@
+declare module '*.ftl?raw' {
+  const content: string;
+  export default content;
+}

--- a/ui/desktop/src/i18n.tsx
+++ b/ui/desktop/src/i18n.tsx
@@ -1,0 +1,16 @@
+import { FluentBundle, FluentResource } from '@fluent/bundle';
+import { LocalizationProvider, ReactLocalization } from '@fluent/react';
+import React from 'react';
+
+import agentHeaderEn from './components/AgentHeader.en.ftl?raw';
+import apiKeyWarningEn from './components/ApiKeyWarning.en.ftl?raw';
+
+const bundle = new FluentBundle('en-US');
+bundle.addResource(new FluentResource(agentHeaderEn));
+bundle.addResource(new FluentResource(apiKeyWarningEn));
+
+export const l10n = new ReactLocalization([bundle]);
+
+export const I18nProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <LocalizationProvider l10n={l10n}>{children}</LocalizationProvider>
+);

--- a/ui/desktop/src/renderer.tsx
+++ b/ui/desktop/src/renderer.tsx
@@ -2,6 +2,7 @@ import React, { Suspense, lazy } from 'react';
 import ReactDOM from 'react-dom/client';
 import { ConfigProvider } from './components/ConfigContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { I18nProvider } from './i18n';
 import { patchConsoleLogging } from './utils';
 import SuspenseLoader from './suspense-loader';
 
@@ -14,7 +15,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <Suspense fallback={SuspenseLoader()}>
       <ConfigProvider>
         <ErrorBoundary>
-          <App />
+          <I18nProvider>
+            <App />
+          </I18nProvider>
         </ErrorBoundary>
       </ConfigProvider>
     </Suspense>


### PR DESCRIPTION
## Summary
- add `@fluent/bundle` and `@fluent/react` dependencies
- create `i18n` setup with a new provider
- localize `AgentHeader` and `ApiKeyWarning` components
- add English `.ftl` message files
- include `.ftl` raw module declaration

## Testing
- `cargo check` *(fails: protoc missing)*
- `npm run lint:check`


------
https://chatgpt.com/codex/tasks/task_e_684df7176b5483298d9a40cee8009022